### PR TITLE
[BREAKING CHANGE] server/controller/sticks: Actually match the JavaScript Gamepad API

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -72,7 +72,16 @@ Example: move the right stick to the left with `'s r left'` and then set it back
 For moving by a specific amount: `s <stick> <direction> <amount>`
 * stick: left: `l` or right: `r`
 * direction: horizontal: `h` or vertical: `v`
-* amount: `max`, `min`, `center`, or a decimal number between `-1.0` and `1.0` (down to up or left to right - set up to match the [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/))
+* amount:
+  * For your convenience with writing easy to read macros/code:
+    * UP/RIGHT: `max`
+    * DOWN/LEFT: `min`
+    * back to the calibrated center: `center`
+    * for convenience with matching the [JavaScript Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/)
+    a decimal number between `-1.0` and `1.0`:
+      * UP/LEFT: `-1.0` (yes `-1.0` is UP, this is how the Gamepad API works)
+      * DOWN/RIGHT: `1.0`
+      * back to the calibrated center: `0` 
 
 Examples:
 * Push the left stick up all the way: `'s l v max'`, then let go of it and set it back to it's center position with: `'s l v center'`.

--- a/server/README.md
+++ b/server/README.md
@@ -77,11 +77,11 @@ For moving by a specific amount: `s <stick> <direction> <amount>`
     * UP/RIGHT: `max`
     * DOWN/LEFT: `min`
     * back to the calibrated center: `center`
-    * for convenience with matching the [JavaScript Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/)
-    a decimal number between `-1.0` and `1.0`:
-      * UP/LEFT: `-1.0` (yes `-1.0` is UP, this is how the Gamepad API works)
-      * DOWN/RIGHT: `1.0`
-      * back to the calibrated center: `0` 
+  * For convenience with matching the [JavaScript Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/)
+a decimal number between `-1.0` and `1.0`:
+    * UP/LEFT: `-1.0` (yes `-1.0` is UP, this is how the Gamepad API works)
+    * DOWN/RIGHT: `1.0`
+    * back to the calibrated center: `0` 
 
 Examples:
 * Push the left stick up all the way: `'s l v max'`, then let go of it and set it back to it's center position with: `'s l v center'`.

--- a/server/switchremoteplay/controller.py
+++ b/server/switchremoteplay/controller.py
@@ -56,9 +56,10 @@ class SwitchController():
 			val = stick.get_calibration().h_center
 		else:
 			try:
-				min_val = stick.get_calibration().h_center - stick.get_calibration().h_max_below_center
-				max_val = stick.get_calibration().h_center + stick.get_calibration().h_max_above_center
-				val = SwitchController._map_val(float(value), min_val, max_val)
+				# LEFT: -1, RIGHT: +1
+				left_val = stick.get_calibration().h_center - stick.get_calibration().h_max_below_center
+				right_val = stick.get_calibration().h_center + stick.get_calibration().h_max_above_center
+				val = SwitchController._map_val(float(value), left_val, right_val)
 			except ValueError:
 				raise ValueError(f'Unexpected stick value "{value}"')
 		return val
@@ -74,9 +75,10 @@ class SwitchController():
 			val = stick.get_calibration().v_center
 		else:
 			try:
-				min_val = stick.get_calibration().v_center - stick.get_calibration().v_max_below_center
-				max_val = stick.get_calibration().v_center + stick.get_calibration().v_max_above_center
-				val = SwitchController._map_val(float(value), min_val, max_val)
+				# Match the JavaScript Gamepad API: UP: -1, DOWN: +1
+				down_val = stick.get_calibration().v_center - stick.get_calibration().v_max_below_center
+				up_val = stick.get_calibration().v_center + stick.get_calibration().v_max_above_center
+				val = SwitchController._map_val(float(value), up_val, down_val)
 			except ValueError:
 				raise ValueError(f'Unexpected stick value "{value}"')
 		return val

--- a/server/switchremoteplay/tests/test_controller.py
+++ b/server/switchremoteplay/tests/test_controller.py
@@ -6,9 +6,18 @@ from switchremoteplay.controller import SwitchController
 class TestSwitchController(unittest.TestCase):
 	def test_map_val(self):
 		min_val = 0
-		max_val = 0x1000
+		max_val = 0x1000 - 1
+		# Mapping the horizontal axis: left (-1) to right (+1)
 		assert SwitchController._map_val(-1, min_val, max_val) == min_val
 		assert SwitchController._map_val(+1, min_val, max_val) == max_val
-		assert SwitchController._map_val(0, min_val, max_val) == (min_val + max_val) / 2
-		assert SwitchController._map_val(-0.5, min_val, max_val) == (min_val + max_val) / 4
-		assert SwitchController._map_val(+0.5, min_val, max_val) == (min_val + max_val) * 3 / 4
+		self.assertEqual(SwitchController._map_val(0, min_val, max_val), int((min_val + max_val) / 2))
+		assert SwitchController._map_val(-0.5, min_val, max_val) == int((min_val + max_val) / 4)
+		assert SwitchController._map_val(+0.5, min_val, max_val) == int((min_val + max_val) * 3 / 4)
+
+		# Mapping the vertical axis: up (-1) to down (+1)
+		assert SwitchController._map_val(-1, max_val, min_val) == max_val
+		assert SwitchController._map_val(+1, max_val, min_val) == min_val
+		assert SwitchController._map_val(0, max_val, min_val) == int((min_val + max_val) / 2)
+		assert SwitchController._map_val(-0.5, max_val, min_val) == int((min_val + max_val) * 3 / 4)
+		assert SwitchController._map_val(+0.5, max_val, min_val) == int((min_val + max_val) / 4)
+


### PR DESCRIPTION
The handling of the `s l v <amount>` has changed. `<amount>` is inverted to match the Gamepad API.
UP: s l v -1
DOWN: s l v 1